### PR TITLE
corrected licenses and local repolint

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,6 @@
 # Network SubSytem(NSS)-firmware
 
 Firmware files for NSS, a network acceleration engine for Qualcomm Technologies 802.11ax devices
+
+## License
+qca-sdk-nss-fw is licensed under the BSD 3-clause "New" or "Revised" License. Check out the [LICENSE](https://github.com/quic/qca-sdk-nss-fw/edit/main/LICENSE.md) for more details.

--- a/repolint.json
+++ b/repolint.json
@@ -1,0 +1,45 @@
+{
+    "extends": "https://raw.githubusercontent.com/quic/.github/main/repolint.json",
+    "rules": {
+      "source-license-headers-exist": {
+        "level": "error",
+        "rule": {
+          "type": "file-starts-with",
+          "options": {
+            "globsAll": [
+              "**/*.py",
+              "**/*.js",
+              "**/*.c",
+              "**/*.cc",
+              "**/*.cpp",
+              "**/*.h",
+              "**/*.ts",
+              "**/*.sh",
+              "**/*.rs",
+              "**/*.java",
+              "**/*.go",
+              "**/*.bbclass",
+              "**/*.S"
+            ],
+            "skip-paths-matching": {
+              "patterns": [
+                "babel.config.js",
+                "build\/",
+                "jest.config.js",
+                "node_modules\/",
+                "types\/",
+                "uthash.h"
+              ]
+            },
+            "lineCount": 60,
+            "patterns": [
+              "(Copyright|©).*Qualcomm Innovation Center, Inc|Copyright (\\(c\\)|©) (20(1[2-9]|2[0-2])(-|,|\\s)*)+ The Linux Foundation",
+              "SPDX-License-Identifier|Redistribution and use in source and binary forms, with or without"
+            ],
+            "flags": "i",
+            "succeed-on-non-existent": true
+          }
+        }
+      }
+    }
+  }


### PR DESCRIPTION
### Description
Repolinter Audit results:

 repolinter lint -g https://github.com/quic/qca-sdk-nss-fw --rulesetUrl https://raw.githubusercontent.com/quic/.github/main/repolint.json                 
Target directory: C:\Users\nwtn\AppData\Local\Temp\repolinter-PLpeTr
Axiom language failed to run with error: Linguist not installed
Axiom license failed to run with error: Error executing licensee
Lint:
✔ license-file-exists: Found file (LICENSE.md)
✔ readme-file-exists: Found file (README.md)
⚠ contributing-file-exists: Did not find a file matching the specified patterns ({docs/,.github/,}CONTRIB*)
⚠ code-of-conduct-file-exists: Did not find a file matching the specified patterns
        ⚠ {docs/,.github/,}CODEOFCONDUCT*
        ⚠ {docs/,.github/,}CODE-OF-CONDUCT*
        ⚠ {docs/,.github/,}CODE_OF_CONDUCT*
⚠ changelog-file-exists: Did not find a file matching the specified patterns (CHANGELOG*)
✖ readme-references-license: Doesn't contain license|notice (README.md)
✔ binaries-not-present: Excluded file type doesn't exist (*/.exe,*/.dll,*/.o,*/.so,!node_modules/**)
⚠ test-directory-exists: Did not find a file matching the specified patterns
        ⚠ */test
        ⚠ **/specs
        ⚠ **/test
✔ integrates-with-ci: Found file (.github/workflows/quic-organization-repolinter.yml)
✖ source-license-headers-exist: Did not find file matching the specified patterns
        ✖ */.py
        ✖ */.js
        ✖ */.c
        ✖ */.cc
        ✖ */.cpp
        ✖ */.h
        ✖ */.ts
        ✖ */.sh
        ✖ */.rs
        ✖ */.java
        ✖ */.go
        ✖ */.bbclass
        ✖ */.S
✔ bb-file-license-exist: Did not find file matching the specified patterns (*/.bb)
⚠ github-issue-template-exists: Did not find a file matching the specified patterns
        ⚠ ISSUE_TEMPLATE*
        ⚠ .github/ISSUE_TEMPLATE*